### PR TITLE
Handle missing images during test prediction

### DIFF
--- a/yolo.py
+++ b/yolo.py
@@ -99,13 +99,26 @@ def main():
 
     # Dự đoán trên tập test
     test_path = data_path / "test"
-    if test_path.exists() and any(test_path.iterdir()):
-        print("\nDự đoán trên tập test:")
-        results = model.predict(source=str(test_path))
-        for r in results[:3]:  # Hiển thị 3 kết quả đầu
-            print(f"{Path(r.path).name}: {r.names[r.probs.top1]} (confidence: {r.probs.top1conf:.2f})")
+    if test_path.exists():
+        # Thu thập tất cả đường dẫn ảnh hợp lệ trong các thư mục con
+        test_images = [
+            p for p in test_path.rglob("*")
+            if p.is_file() and p.suffix.lower() in IMG_EXTS
+        ]
+
+        if test_images:
+            print("\nDự đoán trên tập test:")
+            # model.predict hỗ trợ truyền danh sách các đường dẫn ảnh
+            results = model.predict(source=[str(p) for p in test_images])
+            for r in results[:3]:  # Hiển thị 3 kết quả đầu
+                print(
+                    f"{Path(r.path).name}: {r.names[r.probs.top1]} "
+                    f"(confidence: {r.probs.top1conf:.2f})"
+                )
+        else:
+            print("\n⚠️ Không tìm thấy ảnh trong tập test")
     else:
-        print("\n⚠️ Không tìm thấy ảnh trong tập test")
+        print("\n⚠️ Không tìm thấy thư mục test")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Recursively collect all images in `graph_dataset_split/test` before running predictions
- Warn if the test directory or images are missing

## Testing
- `python -m py_compile yolo.py`

------
https://chatgpt.com/codex/tasks/task_b_689c8df38e64832ba8c4aad7c621b52a